### PR TITLE
Set DEBUG to False when running in production from docker container

### DIFF
--- a/covid19/covid19/settings.py
+++ b/covid19/covid19/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '7e!d9l_a_v%psq+u*h16w&i3hon*t7i!j(p3$gyq=47kuf8=3s'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", True)
 
 ALLOWED_HOSTS = ["tao.asvo.org.au", "localhost"]
 

--- a/covid19/docker/web.Dockerfile
+++ b/covid19/docker/web.Dockerfile
@@ -8,6 +8,8 @@ RUN apk add mariadb-dev gcc libc-dev
 # REQUIREMENTS: PIP
 RUN pip3 install -r /app/requirements/pip.txt
 
+ENV DEBUG=False
+
 # CLEAN UP: APT
 RUN apk del libc-dev gcc
 


### PR DESCRIPTION
Disable the DEBUG setting in Django when running in production in the Docker container

Running in DEBUG is a high security risk